### PR TITLE
Add sleep in render loop to limit the framerate

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -11,6 +11,8 @@ static const EGLint egl_config[] = {
 	EGL_NONE
 };
 
+static const unsigned int framerate = 60;
+
 /*
  * Star Nest by Pablo Román Andrioli
  * https://www.shadertoy.com/view/XlfGRj

--- a/sstoy.c
+++ b/sstoy.c
@@ -311,7 +311,8 @@ void render(double abstime)
 
 int main(int argc, char **argv)
 {
-	struct timespec start, cur;
+	struct timespec start, cur, mfr;
+	mfr = (struct timespec){ .tv_sec = 0, .tv_nsec = 1000000000 / framerate };
 
 	startup();
 	monotonic_time(&start);
@@ -321,6 +322,7 @@ int main(int argc, char **argv)
 			break;
 		render(timespec_diff(&start, &cur));
 		monotonic_time(&cur);
+		nanosleep(&mfr, NULL);
 	}
 
 	shutdown();


### PR DESCRIPTION
To enable users to save processing time when the extra frames would go beyond their monitor's (or eyes'?) refresh rate